### PR TITLE
no reason to memcpy the bsb_samples

### DIFF
--- a/rpi-interface.c
+++ b/rpi-interface.c
@@ -981,7 +981,7 @@ void sigint_handler(int val)
 }
 
 //samples per symbol (sps) = 5
-void filter_symbols(int8_t out[SYM_PER_FRA*5], const int8_t in[SYM_PER_FRA], const float* flt, uint8_t phase_inv)
+void filter_symbols(int8_t *out, const int8_t *in, const float* flt, uint8_t phase_inv)
 {
 	#define FLT_LEN 41
 	static int8_t last[FLT_LEN]; //memory for last symbols
@@ -1653,8 +1653,7 @@ int main(int argc, char* argv[])
 				memcpy(m17stream.pld, &rx_buff[(32+16+224+16)/8U], 128/8);
 
 				int8_t frame_symbols[SYM_PER_FRA];						//raw frame symbols
-				int8_t bsb_samples[SYM_PER_FRA*5];						//filtered baseband samples = symbols*sps
-				uint8_t bsb_chunk[963] = {CMD_TX_DATA, 0xC3, 0x03};		//baseband samples wrapped in a frame
+				int8_t bsb_samples[963] = {CMD_TX_DATA, 0xC3, 0x03};	//baseband samples wrapped in a frame
 
 				if(tx_state==TX_IDLE) //first received frame
 				{
@@ -1737,25 +1736,22 @@ int main(int argc, char* argv[])
 					gen_preamble_i8(frame_symbols, &frame_buff_cnt, PREAM_LSF);
 
 					//filter and send out to the device
-					filter_symbols(bsb_samples, frame_symbols, rrc_taps_5, 0);
-					memcpy(&bsb_chunk[3], bsb_samples, sizeof(bsb_samples));
-					write(fd, (uint8_t*)bsb_chunk, sizeof(bsb_chunk));
+					filter_symbols(bsb_samples+3, frame_symbols, rrc_taps_5, 0);
+					write(fd, bsb_samples, sizeof(bsb_samples));
 
 					//now the LSF
 					gen_frame_i8(frame_symbols, NULL, FRAME_LSF, &(m17stream.lsf), 0, 0);
 
 					//filter and send out to the device
-					filter_symbols(bsb_samples, frame_symbols, rrc_taps_5, 0);
-					memcpy(&bsb_chunk[3], bsb_samples, sizeof(bsb_samples));
-					write(fd, (uint8_t*)bsb_chunk, sizeof(bsb_chunk));
+					filter_symbols(bsb_samples+3, frame_symbols, rrc_taps_5, 0);
+					write(fd, bsb_samples, sizeof(bsb_samples));
 
 					//finally, the first frame
 					gen_frame_i8(frame_symbols, m17stream.pld, FRAME_STR, &(m17stream.lsf), (m17stream.fn&0x7FFFU)%6, m17stream.fn);
 
 					//filter and send out to the device
-					filter_symbols(bsb_samples, frame_symbols, rrc_taps_5, 0);
-					memcpy(&bsb_chunk[3], bsb_samples, sizeof(bsb_samples));
-					write(fd, (uint8_t*)bsb_chunk, sizeof(bsb_chunk));
+					filter_symbols(bsb_samples+3, frame_symbols, rrc_taps_5, 0);
+					write(fd, bsb_samples, sizeof(bsb_samples));
 				}
 				else
 				{
@@ -1763,9 +1759,8 @@ int main(int argc, char* argv[])
 					gen_frame_i8(frame_symbols, m17stream.pld, FRAME_STR, &(m17stream.lsf), (m17stream.fn&0x7FFFU)%6, m17stream.fn);
 
 					//filter and send out to the device
-					filter_symbols(bsb_samples, frame_symbols, rrc_taps_5, 0);
-					memcpy(&bsb_chunk[3], bsb_samples, sizeof(bsb_samples));
-					write(fd, (uint8_t*)bsb_chunk, sizeof(bsb_chunk));
+					filter_symbols(bsb_samples+3, frame_symbols, rrc_taps_5, 0);
+					write(fd, bsb_samples, sizeof(bsb_samples));
 				}
 
 				time(&rawtime);
@@ -1786,9 +1781,8 @@ int main(int argc, char* argv[])
 					gen_eot_i8(frame_symbols, &frame_buff_cnt);
 
 					//filter and send out to the device
-					filter_symbols(bsb_samples, frame_symbols, rrc_taps_5, 0);
-					memcpy(&bsb_chunk[3], bsb_samples, sizeof(bsb_samples));
-					write(fd, (uint8_t*)bsb_chunk, sizeof(bsb_chunk));
+					filter_symbols(bsb_samples+3, frame_symbols, rrc_taps_5, 0);
+					write(fd, bsb_samples, sizeof(bsb_samples));
 
 					time(&rawtime);
 					timeinfo=localtime(&rawtime);
@@ -1882,7 +1876,7 @@ int main(int argc, char* argv[])
 				//filter and send out to the device
 				filter_symbols(bsb_samples, frame_symbols, rrc_taps_5, 0);
 				memcpy(&bsb_chunk[3], bsb_samples, sizeof(bsb_samples));
-				write(fd, (uint8_t*)bsb_chunk, sizeof(bsb_chunk));
+				write(fd, bsb_samples, sizeof(bsb_samples));
 				
 				//now the LSF
 				gen_frame_i8(frame_symbols, NULL, FRAME_LSF, (lsf_t*)&rx_buff[4], 0, 0);
@@ -1890,7 +1884,7 @@ int main(int argc, char* argv[])
 				//filter and send out to the device
 				filter_symbols(bsb_samples, frame_symbols, rrc_taps_5, 0);
 				memcpy(&bsb_chunk[3], bsb_samples, sizeof(bsb_samples));
-				write(fd, (uint8_t*)bsb_chunk, sizeof(bsb_chunk));
+				write(fd, bsb_samples, sizeof(bsb_samples));
 				
 				//packet frames
 				uint16_t pld_len=rx_len-(4+240/8); //"M17P" plus 240-bit LSD
@@ -1904,7 +1898,7 @@ int main(int argc, char* argv[])
 					gen_frame_i8(frame_symbols, pld, FRAME_PKT, NULL, 0, 0);
 					filter_symbols(bsb_samples, frame_symbols, rrc_taps_5, 0);
 					memcpy(&bsb_chunk[3], bsb_samples, sizeof(bsb_samples));
-					write(fd, (uint8_t*)bsb_chunk, sizeof(bsb_chunk));
+					write(fd, bsb_samples, sizeof(bsb_samples));
 					pld_len-=25;
 					frame++;
 					usleep(40*1000U);
@@ -1915,7 +1909,7 @@ int main(int argc, char* argv[])
 				gen_frame_i8(frame_symbols, pld, FRAME_PKT, NULL, 0, 0);
 				filter_symbols(bsb_samples, frame_symbols, rrc_taps_5, 0);
 				memcpy(&bsb_chunk[3], bsb_samples, sizeof(bsb_samples));
-				write(fd, (uint8_t*)bsb_chunk, sizeof(bsb_chunk));
+				write(fd, bsb_samples, sizeof(bsb_samples));
 				usleep(40*1000U);
 
 				//now the final EOT marker
@@ -1925,7 +1919,7 @@ int main(int argc, char* argv[])
 				//filter and send out to the device
 				filter_symbols(bsb_samples, frame_symbols, rrc_taps_5, 0);
 				memcpy(&bsb_chunk[3], bsb_samples, sizeof(bsb_samples));
-				write(fd, (uint8_t*)bsb_chunk, sizeof(bsb_chunk));
+				write(fd, bsb_samples, sizeof(bsb_samples));
 
 				time(&rawtime);
 				timeinfo=localtime(&rawtime);


### PR DESCRIPTION
Calling filter_symbols() with an offset will save having to copy the data from one place to another before writing to the device.

Also, write() takes a pointer to void, so there is no reason to recast  (int8_t *)  to (uint8_t *).