### PR TITLE
fixes a segv error, which I think only occurs with optimized code.

### DIFF
--- a/rpi-interface.c
+++ b/rpi-interface.c
@@ -1742,8 +1742,8 @@ int main(int argc, char* argv[])
 
 					//generate META field
 					//remove trailing spaces and suffixes
-					uint8_t trimmed_src[12], enc_trimmed_src[6];
-					for(uint8_t i=0; i<12; i++)
+					uint8_t trimmed_src[10], enc_trimmed_src[6];
+					for(uint8_t i=0; i<10; i++)
 					{
 						if(src_call[i]!=' ')
 							trimmed_src[i]=src_call[i];


### PR DESCRIPTION
I'm worried about this. I think it has something to do with the -O2 optimization. The core dump says the segv occurred on line 1746 while processing of the callsign `N7TAE`, a 5 byte callsign, but when I asked to see the value of `i`, I could not because gdb said it was optimized out. Yikes!